### PR TITLE
Silence warnings

### DIFF
--- a/CDSPBlockConvolver.h
+++ b/CDSPBlockConvolver.h
@@ -322,13 +322,13 @@ public:
 
 				#if R8B_FLOATFFT
 					float* const kb = (float*) Filter -> getKernelBlock();
-					float* const op = (float*) CurInput;
+					float* const op_ = (float*) CurInput;
 				#else // R8B_FLOATFFT
 					const double* const kb = Filter -> getKernelBlock();
-					double* const op = CurInput;
+					double* const op_ = CurInput;
 				#endif // R8B_FLOATFFT
 
-				op[ 1 ] = kb[ z ] * op[ z ] - kb[ z + 1 ] * op[ z + 1 ];
+				op_[ 1 ] = kb[ z ] * op_[ z ] - kb[ z + 1 ] * op_[ z + 1 ];
 			}
 
 			(*fftout) -> inverse( CurInput );

--- a/CDSPResampler.h
+++ b/CDSPResampler.h
@@ -332,7 +332,7 @@ public:
 
 		const int SrcSRDiv = ( 1 << c );
 		int downf;
-		double NormFreq;
+		double NormFreq = 0.0;
 		bool UseInterp = true;
 		bool IsThird = false;
 


### PR DESCRIPTION
This PR silences two warnings:

1. In CDSPResampler.h, initialize `NormFreq`, as e.g. VS2017 cannot infer that it will be initalized on all code paths, at least not in debug builds.

2. In CSDPBlockConvolver.h, there are two variable declarations named `op` in the same function on different nesting levels, which also causes a warning on various compilers.