### PR TITLE
Added CMake support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Folders
+bin/
+build/
+out/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,98 @@
+cmake_minimum_required(VERSION 3.15)
+project(r8brain-free-src C CXX)
+
+option(R8B_DLL "Build r8brain-free-src as shared library" ON)
+option(R8B_IPP "Use IPP FFT instead of Ooura FFT" OFF)
+option(R8B_PFFFT "Use PFFFT instead of Ooura FFT" OFF)
+option(R8B_PFFFT_DOUBLE "Use PFFFT instead of Ooura FFT" OFF)
+option(R8B_STATIC_CRT "Link MSVC CRT statically" OFF)
+option(R8B_FASTTIMING "Enable fast timing in r8brain-free-src" OFF)
+
+if (R8B_PFFFT_DOUBLE AND R8B_PFFFT)
+	message(FATAL_ERROR "If you want to use PFFFT with double, you should first of all disable R8B_PFFFT.")
+endif()
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND WIN32)
+	message(FATAL_ERROR "ClangCL is not supported yet.")
+endif()
+
+file(GLOB R8B_SRC
+	"CDSPBlockConvolver.h"
+	"CDSPFIRFilter.h"
+	"CDSPFracInterpolator.h"
+	"CDSPHBDownsampler.h"
+	"CDSPHBUpsampler.h"
+	"CDSPHBUpsampler.inc"
+	"CDSPProcessor.h"
+	"CDSPRealFFT.h"
+	"CDSPResampler.h"
+	"CDSPSincFilterGen.h"
+
+	"r8bbase.cpp"
+	"r8bbase.h"
+	
+	"r8bconf.h"
+	"r8butil.h"
+)
+
+file(GLOB R8B_DLL_SRC
+	"DLL/r8bsrc.cpp"
+	"DLL/r8bsrc.h"
+)
+
+if (R8B_PFFFT)
+	file(GLOB FFT_SRC
+		"pffft.cpp"
+		"pffft.h"
+	)
+else()
+	if (R8B_PFFFT_DOUBLE)
+		file(GLOB FFT_SRC
+			"pffft_double/pffft_double.c"
+			"pffft_double/pffft_double.h"
+		)
+	else()
+		file(GLOB FFT_SRC "fft4g.h")
+	endif()
+endif()
+
+if (R8B_DLL)
+	add_library(r8brain SHARED ${R8B_SRC} ${FFT_SRC} ${R8B_DLL_SRC})
+else()
+	add_library(r8brain STATIC ${R8B_SRC} ${FFT_SRC})
+endif()
+	
+target_include_directories(r8brain PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}) # public include for usage
+target_include_directories(r8brain PRIVATE "DLL")
+target_include_directories(r8brain PRIVATE "pffft_double")
+
+if (R8B_FASTTIMING)
+	target_compile_definitions(r8brain PUBLIC "R8B_FASTTIMING=1")
+endif()
+
+if (R8B_IPP)
+	target_compile_definitions(r8brain PUBLIC "R8B_IPP=1")
+endif()
+
+if (R8B_PFFFT)
+	target_compile_definitions(r8brain PUBLIC "R8B_PFFFT=1")
+endif()
+
+if (R8B_PFFFT_DOUBLE)
+	target_compile_definitions(r8brain PUBLIC "R8B_PFFFT_DOUBLE=1")
+endif()
+
+if (R8B_DLL)
+	target_compile_definitions(r8brain PUBLIC R8B_DLL)
+	target_compile_definitions(r8brain PRIVATE R8B_DLL_EXPORT)
+endif()
+	
+set_target_properties(r8brain
+	PROPERTIES
+		LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/bin/"
+		RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/bin/"
+)
+
+if (R8B_STATIC_CRT)
+	set_property(TARGET r8brain PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()

--- a/DLL/r8bsrc.cpp
+++ b/DLL/r8bsrc.cpp
@@ -60,7 +60,7 @@ CAutoDispatchInit AutoDispatchInit;
 
 extern "C" {
 
-CR8BResampler _cdecl r8b_create( const double SrcSampleRate,
+CR8BResampler R8BRAIN_API r8b_create( const double SrcSampleRate,
 	const double DstSampleRate, const int MaxInLen, const double ReqTransBand,
 	const ER8BResamplerRes Res )
 {
@@ -80,17 +80,17 @@ CR8BResampler _cdecl r8b_create( const double SrcSampleRate,
 		ReqTransBand ));
 }
 
-void _cdecl r8b_delete( CR8BResampler const rs )
+void R8BRAIN_API r8b_delete( CR8BResampler const rs )
 {
 	delete (CDSPProcessor*) rs;
 }
 
-void _cdecl r8b_clear( CR8BResampler const rs )
+void R8BRAIN_API r8b_clear( CR8BResampler const rs )
 {
 	( (CDSPProcessor*) rs ) -> clear();
 }
 
-int _cdecl r8b_process( CR8BResampler const rs, double* const ip0, int l,
+int R8BRAIN_API r8b_process( CR8BResampler const rs, double* const ip0, int l,
 	double*& op0 )
 {
 	return(( (CDSPProcessor*) rs ) -> process( ip0, l, op0 ));

--- a/DLL/r8bsrc.h
+++ b/DLL/r8bsrc.h
@@ -26,12 +26,12 @@
 
 #ifdef R8B_DLL
 #if defined (__GNUC__) && ((__GNUC__ >= 4) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 1)))
-#define R8BRAIN_API	__attribute__ ((visibility ("default")))
+#define R8BRAIN_API __attribute__((visibility ("default")))
 #else
 #ifdef R8B_DLL_EXPORT
 #define R8BRAIN_API __declspec(dllexport)
 #else
-#define R8BRAIN_API __declspec(dllexport)
+#define R8BRAIN_API __declspec(dllimport)
 #endif
 #endif
 #else

--- a/DLL/r8bsrc.h
+++ b/DLL/r8bsrc.h
@@ -24,6 +24,20 @@
 #ifndef R8BSRC_INCLUDED
 #define R8BSRC_INCLUDED
 
+#ifdef R8B_DLL
+#if defined (__GNUC__) && ((__GNUC__ >= 4) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 1)))
+#define R8BRAIN_API	__attribute__ ((visibility ("default")))
+#else
+#ifdef R8B_DLL_EXPORT
+#define R8BRAIN_API __declspec(dllexport)
+#else
+#define R8BRAIN_API __declspec(dllexport)
+#endif
+#endif
+#else
+#define R8BRAIN_API _cdecl
+#endif
+
 /**
  * Resampler object handle.
  */
@@ -61,7 +75,7 @@ extern "C" {
  * @param Res Resampler's required resolution.
  */
 
-CR8BResampler _cdecl r8b_create( const double SrcSampleRate,
+CR8BResampler R8BRAIN_API r8b_create( const double SrcSampleRate,
 	const double DstSampleRate, const int MaxInLen,
 	const double ReqTransBand, const ER8BResamplerRes Res );
 
@@ -72,7 +86,7 @@ CR8BResampler _cdecl r8b_create( const double SrcSampleRate,
  * @param rs Resampler object to delete.
  */
 
-void _cdecl r8b_delete( CR8BResampler const rs );
+void R8BRAIN_API r8b_delete( CR8BResampler const rs );
 
 /**
  * Function clears (resets) the state of the resampler object and returns it
@@ -82,7 +96,7 @@ void _cdecl r8b_delete( CR8BResampler const rs );
  * @param rs Resampler object to clear.
  */
 
-void _cdecl r8b_clear( CR8BResampler const rs );
+void R8BRAIN_API r8b_clear( CR8BResampler const rs );
 
 /**
  * Function performs sample rate conversion.
@@ -111,7 +125,7 @@ void _cdecl r8b_clear( CR8BResampler const rs );
  * overflow of the bigger output buffer happens.
  */
 
-int _cdecl r8b_process( CR8BResampler const rs, double* const ip0, int l,
+int R8BRAIN_API r8b_process( CR8BResampler const rs, double* const ip0, int l,
 	double*& op0 );
 
 } // extern "C"


### PR DESCRIPTION
Very often I have to write a `CMakeLists.txt` file manually for each library, so I decided to make it public. 

This `CMakeLists.txt` file has minimal functionality to support external library integration via CMake (via add_subdirectory). Ideally, I'd write `Find_R8Brain.cmake` and distribute by vcpkg/conan, but I don't think it's worth it now.